### PR TITLE
choose database

### DIFF
--- a/docs/decisions/004-choose-database/allegrograph.yaml
+++ b/docs/decisions/004-choose-database/allegrograph.yaml
@@ -1,0 +1,6 @@
+$id: https://allegrograph.com/
+ui-support: native
+license: proprietary
+python-client: https://github.com/franzinc/agraph-python
+sparql-support:
+  version: 1.1

--- a/docs/decisions/004-choose-database/anzograph.yaml
+++ b/docs/decisions/004-choose-database/anzograph.yaml
@@ -1,0 +1,4 @@
+$id: https://www.cambridgesemantics.com/anzograph/
+license: proprietary
+sparql-support:
+  version: 1.1

--- a/docs/decisions/004-choose-database/blazegraph.yaml
+++ b/docs/decisions/004-choose-database/blazegraph.yaml
@@ -1,0 +1,4 @@
+$id: https://blazegraph.com
+sparql-support:
+  version: 1.1
+license: proprietary

--- a/docs/decisions/004-choose-database/context.yaml
+++ b/docs/decisions/004-choose-database/context.yaml
@@ -1,0 +1,14 @@
+ui-support:
+  $type: $id
+
+python-client:
+  $type: $id
+
+reasoning-support:
+  $type: $id
+
+sparqlwrapper:
+  $id: https://rdflib.dev/sparqlwrapper/
+
+command-line-client:
+  $type: $id

--- a/docs/decisions/004-choose-database/fuseki.yaml
+++ b/docs/decisions/004-choose-database/fuseki.yaml
@@ -1,0 +1,8 @@
+$id: https://jena.apache.org/documentation/fuseki2/index.html
+sparql-support:
+  version: 1.1
+ui-support: native
+python-client:
+  - https://github.com/blazegraph/blazegraph-python
+  - sparqlwrapper
+license: Apache

--- a/docs/decisions/004-choose-database/graphdb.yaml
+++ b/docs/decisions/004-choose-database/graphdb.yaml
@@ -1,0 +1,9 @@
+$id: https://www.ontotext.com/products/graphdb
+sparql-support:
+  version: 1.1
+reasoning-support:
+  - owl-rl
+  - owl-ql
+ui-support: native
+python-client: sparqlwrapper
+license: proprietary

--- a/docs/decisions/004-choose-database/index.md
+++ b/docs/decisions/004-choose-database/index.md
@@ -1,0 +1,24 @@
+---
+title: Choosing database engine
+source:
+  - https://en.wikipedia.org/wiki/Comparison_of_triplestores
+  - https://www.w3.org/2001/sw/wiki/ToolTable
+  - http://www.michelepasin.org/blog/2011/02/24/survey-of-pythonic-tools-for-rdf-and-linked-data-programming/
+---
+
+## Context
+
+At this point, I consider the transient in-memory storage of RDF graph (the one RDFLib provides us with) a blocker for further development because:
+
+- OWL RL reasoning on this graph is extremely slow;
+- It is impossible to use information from the graph for third-party instruments;
+- There is no interactive UI to debug the graph;
+- The graph is rebuilt from scratch every time we build (or serve) the site.
+
+I believe we need to choose a database we are going to persist our data in.
+
+## Decision
+
+
+
+## Consequences

--- a/docs/decisions/004-choose-database/index.md
+++ b/docs/decisions/004-choose-database/index.md
@@ -15,10 +15,65 @@ At this point, I consider the transient in-memory storage of RDF graph (the one 
 - There is no interactive UI to debug the graph;
 - The graph is rebuilt from scratch every time we build (or serve) the site.
 
-I believe we need to choose a database we are going to persist our data in.
+I believe we need to choose a method we are going to persist our data with.
 
-## Decision
+## Candidates
 
+### TerminusDB
 
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Features</th>
+      <th>Shortcomings</th>
+    <tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Relevant</th>
+      <td>
+        <ul>
+          <li>Very nice admin UI</li>
+          <li>WOQL is JSON-LD based</li>
+          <li>Python query DSL</li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>Lack for SPARQL support</li>
+          <li>Have to run a separate server process</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th>Irrelevant</th>
+      <td>
+        <ul>
+          <li>Git-like versioning</li>
+          <li></li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>?</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Notes
+
+The most important problem in the list above is performance. OWL RL performance is extremely slow and makes the editing experience quite bad even on a modest size documentation database, which I experienced on [https://vocabulari.es](vocabulari.es). 
+
+This does not yet justify completely rejecting SPARQL as a query standard, or abandoning the principle when you do not need to run an extra DB server to use Octadocs. You just run `mkdocs serve` and everything works, out of the box. 
 
 ## Consequences
+
+I will:
+
+- Enable SQlite storage for RDFLib as the default method;
+- Look into methods to optimize the speed;
+- Optimize context generation and store modification times in the graph rather then in a special dictionary in RAM;
+- Perhaps look into supporting Oxigraph and other SPARQL-enabled stores.

--- a/docs/decisions/004-choose-database/meta.yaml
+++ b/docs/decisions/004-choose-database/meta.yaml
@@ -1,0 +1,16 @@
+- $id: KGStore
+  $type: rdfs:Class
+
+- $id: SPARQLSupport
+  $type: rdfs:Class
+
+- $id: sparql-support
+  rdfs:domain: KGStore
+  rdfs:range: SPARQLSupport
+
+- $id: version
+  rdfs:domain: SPARQLSupport
+  rdfs:range: xsd:string
+
+- $id: native
+  label: Native

--- a/docs/decisions/004-choose-database/oxigraph.yaml
+++ b/docs/decisions/004-choose-database/oxigraph.yaml
@@ -1,0 +1,8 @@
+$id: https://github.com/oxigraph/oxigraph
+sparql-support:
+  version: 1.1
+rdflib-support:
+  $id: https://github.com/oxigraph/oxrdflib
+license:
+  - MIT
+  - Apache

--- a/docs/decisions/004-choose-database/rdfox.yaml
+++ b/docs/decisions/004-choose-database/rdfox.yaml
@@ -1,0 +1,2 @@
+$id: https://www.oxfordsemantic.tech
+license: proprietary

--- a/docs/decisions/004-choose-database/redland.yaml
+++ b/docs/decisions/004-choose-database/redland.yaml
@@ -1,0 +1,5 @@
+$id: https://librdf.org
+sparql-support:
+  version: 1.1
+python-client: https://librdf.org/docs/python.html
+command-line-client: https://librdf.org/rasqal/roqet.html

--- a/docs/decisions/004-choose-database/stardog.yaml
+++ b/docs/decisions/004-choose-database/stardog.yaml
@@ -1,0 +1,6 @@
+$id: https://www.stardog.com/
+license: proprietary
+python-client: https://github.com/stardog-union/pystardog
+sparql-support:
+  version: 1.1
+ui-support: native

--- a/docs/decisions/004-choose-database/terminus.yaml
+++ b/docs/decisions/004-choose-database/terminus.yaml
@@ -1,0 +1,8 @@
+$id: https://github.com/terminusdb/terminusdb
+ui-support: native
+sparql-support:
+  version: null
+  comment: No SPARQL support available. The query language is named WOQL.
+python-client:
+  $id: https://github.com/terminusdb/terminusdb-client-python
+  comment: There is a rich Python DSL for querying the database, similar to what I would want to see for SPARQL.

--- a/docs/decisions/004-choose-database/virtuoso.yaml
+++ b/docs/decisions/004-choose-database/virtuoso.yaml
@@ -1,0 +1,5 @@
+$id: https://github.com/openlink/virtuoso-opensource
+license: GPL
+sparql-support:
+  version: 1.1
+ui-support: native


### PR DESCRIPTION
- Clear the named graph when invalidating cache
- Intermediate commit
- One more intermediate commit
- Sort navigation according to graph
- Generate flat pages list
- Fix linters
- Bump version
- Fix cached_property use
- Use singledispatchmethod library
- Refactor navigation.py into a package
- Make linters happy
- Implement octa:isParentOf predicate
- Hotfix: cached_property
- Do not crash on a section without index.md file in it
- Assign titles to sections, taking them from their index pages
- Add Netlify config
- Update theme
- Add some examples of subjectOf and change its implementation
- Add a few documents and specs
- ADR: Choose database
- Add a few thoughts about choosing the DB engine
